### PR TITLE
Fix Vercel config: replace routes with rewrites

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,19 +1,12 @@
 {
-  "routes": [
+  "rewrites": [
     {
-      "src": "^/$",
-      "dest": "/hero-landing.html",
-      "headers": {
-        "Cache-Control": "public, max-age=86400, s-maxage=86400"
-      }
+      "source": "/",
+      "destination": "/hero-landing.html"
     },
     {
-      "src": "^/app/(.*)",
-      "dest": "/$1"
-    },
-    {
-      "src": "^/(.*)$",
-      "dest": "/$1"
+      "source": "/app/(.*)",
+      "destination": "/$1"
     }
   ],
   "headers": [


### PR DESCRIPTION
## Purpose
Fix Vercel deployment error caused by using incompatible configuration options. The user encountered an error stating that `routes` cannot be present when other routing options like `rewrites`, `redirects`, `headers`, `cleanUrls` or `trailingSlash` are used.

## Code changes
- Replaced `routes` array with `rewrites` array in `vercel.json`
- Updated route syntax from `src`/`dest` to `source`/`destination` format
- Removed inline headers configuration from individual routes
- Simplified routing rules while maintaining the same functionality:
  - Root path (`/`) still redirects to `/hero-landing.html`
  - App routes (`/app/*`) still redirect to base paths
- Kept existing `headers` configuration section separate

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/24348628ebd248898e7ba693cd0a7911/echo-world)

👀 [Preview Link](https://24348628ebd248898e7ba693cd0a7911-echo-world.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>24348628ebd248898e7ba693cd0a7911</projectId>-->
<!--<branchName>echo-world</branchName>-->